### PR TITLE
v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.6
+
+- New `NotSharedMap`, `NotSharedStore` and `SharedMapSync`.
+
+- Refactored `SharedMapField` and `SharedStoreField`:
+  - Handle non-shared and shared instances appropriately.
+  - Improved handling of isolate copies and shared references for better consistency across isolates.
+ 
+- `SharedMap`:
+  - Improved resolution and caching mechanisms to enhance performance and reduce redundant operations.
+
 ## 1.0.5
 
 - New `SharedStoreField`.

--- a/lib/src/not_shared_map.dart
+++ b/lib/src/not_shared_map.dart
@@ -1,0 +1,190 @@
+import 'shared_map_base.dart';
+import 'shared_map_cached.dart';
+
+/// NOT shared implementation of [SharedStore].
+class NotSharedStore implements SharedStore {
+  static int _notSharedIDCount = 0;
+
+  @override
+  final String id;
+
+  final NotSharedMap? _notSharedMap;
+
+  NotSharedStore([this._notSharedMap])
+      : id = 'NotSharedStore#${++_notSharedIDCount}';
+
+  @override
+  SharedMap<K, V>? getSharedMap<K, V>(String id) {
+    final notSharedMap = _notSharedMap;
+    return notSharedMap?.id == id
+        ? notSharedMap as SharedMap<K, V>
+        : NotSharedMap<K, V>();
+  }
+
+  NotSharedStoreReference? _sharedReference;
+
+  @override
+  SharedStoreReference sharedReference() =>
+      _sharedReference ??= NotSharedStoreReference(this);
+}
+
+/// NOT shared implementation of [SharedMap].
+class NotSharedMap<K, V> implements SharedMapSync<K, V> {
+  static int _notSharedIDCount = 0;
+
+  @override
+  final String id;
+
+  @override
+  late NotSharedStore sharedStore = NotSharedStore(this);
+
+  final Map<K, V?> _entries = {};
+
+  NotSharedMap() : id = 'NotSharedMap#${++_notSharedIDCount}';
+
+  late final _NotSharedMapCache<K, V> _cached = _NotSharedMapCache(this);
+
+  @override
+  SharedMapCached<K, V> cached({Duration? timeout}) => _cached;
+
+  @override
+  V? get(K key) => _entries[key];
+
+  @override
+  List<K> keys() => _entries.keys.toList();
+
+  @override
+  int length() => _entries.length;
+
+  @override
+  V? put(K key, V? value) => _entries[key];
+
+  @override
+  V? putIfAbsent(K key, V? absentValue) {
+    var prev = _entries[key];
+    if (prev == null) {
+      return _entries[key] = absentValue;
+    } else {
+      return prev;
+    }
+  }
+
+  @override
+  V? remove(K key) => _entries.remove(key);
+
+  @override
+  List<V?> removeAll(List<K> keys) {
+    var values = keys.map((k) => _entries.remove(k)).toList();
+    return values;
+  }
+
+  NotSharedMapReference? _sharedReference;
+
+  @override
+  SharedMapReference sharedReference() =>
+      _sharedReference ??= NotSharedMapReference(this);
+}
+
+class NotSharedStoreReference extends SharedStoreReference {
+  final NotSharedStore notSharedStore;
+
+  NotSharedStoreReference(this.notSharedStore) : super(notSharedStore.id);
+}
+
+class NotSharedMapReference extends SharedMapReference {
+  final NotSharedMap notSharedMap;
+
+  NotSharedMapReference(this.notSharedMap)
+      : super(notSharedMap.id, notSharedMap.sharedStore.sharedReference());
+}
+
+class _NotSharedMapCache<K, V> implements SharedMapCached<K, V> {
+  final NotSharedMap<K, V> _sharedMap;
+  @override
+  final Duration timeout;
+
+  _NotSharedMapCache(this._sharedMap) : timeout = Duration.zero;
+
+  @override
+  String get id => _sharedMap.id;
+
+  @override
+  SharedStore get sharedStore => _sharedMap.sharedStore;
+
+  @override
+  Map<K, V> get cachedEntries => {};
+
+  @override
+  void clearCache() {}
+
+  @override
+  V? get(K key, {Duration? timeout, bool refresh = false}) =>
+      _sharedMap.get(key);
+
+  @override
+  V? put(K key, V? value) => _sharedMap.put(key, value);
+
+  @override
+  V? putIfAbsent(K key, V? absentValue) =>
+      _sharedMap.putIfAbsent(key, absentValue);
+
+  @override
+  V? remove(K key) => _sharedMap.remove(key);
+
+  @override
+  List<V?> removeAll(List<K> keys) => _sharedMap.removeAll(keys);
+
+  @override
+  SharedMapReference sharedReference() => _sharedMap.sharedReference();
+
+  @override
+  List<K> keys({Duration? timeout, bool refresh = false}) => _sharedMap.keys();
+
+  @override
+  int length({Duration? timeout, bool refresh = false}) => _sharedMap.length();
+
+  @override
+  SharedMapCached<K, V> cached({Duration? timeout}) => this;
+
+  @override
+  String toString() =>
+      'SharedMapCachedGeneric[$id@${sharedStore.id}]{timeout: $timeout}->$_sharedMap';
+}
+
+class NotSharedStoreField extends SharedObject implements SharedStoreField {
+  final NotSharedStore _notSharedStore;
+
+  NotSharedStoreField(this._notSharedStore);
+
+  @override
+  SharedStore get sharedStore => _notSharedStore;
+
+  @override
+  String get sharedStoreID => _notSharedStore.id;
+}
+
+class NotSharedMapField<K, V> extends SharedObject
+    implements SharedMapField<K, V> {
+  final NotSharedMap<K, V> _notSharedMap;
+
+  NotSharedMapField(this._notSharedMap);
+
+  @override
+  String get sharedMapID => _notSharedMap.id;
+
+  @override
+  NotSharedStore get sharedStore => _notSharedMap.sharedStore;
+
+  @override
+  SharedMap<K, V> get sharedMap => _notSharedMap;
+
+  @override
+  SharedMap<K, V> get sharedMapSync => _notSharedMap;
+
+  @override
+  SharedMap<K, V>? get trySharedMapSync => _notSharedMap;
+
+  @override
+  SharedMap<K, V> sharedMapCached({Duration? timeout}) =>
+      _notSharedMap.cached();
+}

--- a/lib/src/shared_map_base.dart
+++ b/lib/src/shared_map_base.dart
@@ -1,11 +1,40 @@
 import 'dart:async';
+import 'dart:math' as math;
 
+import 'not_shared_map.dart';
 import 'shared_map_cached.dart';
 import 'shared_map_generic.dart'
     if (dart.library.isolate) 'shared_map_isolate.dart';
 
 /// Base class for [SharedStore] and [SharedMap] implementations.
 abstract class SharedType {
+  static int _uuidCount = 0;
+
+  /// Creates an UUID (Universally Unique Identifier).
+  /// See [SharedStore.fromUUID] and [SharedMap.fromUUID].
+  static String newUUID() {
+    var c = ++_uuidCount;
+    var now = DateTime.now();
+
+    const range = 1999999999;
+
+    var rand1 = math.Random();
+    var rand2 = math.Random(now.microsecondsSinceEpoch);
+
+    var seed3 = (rand1.nextInt(range) ^ rand2.nextInt(range)).abs() ^ c;
+    var rand3 = math.Random(seed3);
+
+    var n1 = rand1.nextInt(range);
+    var n2 = rand2.nextInt(range);
+    var n3 = rand3.nextInt(range);
+
+    var n4 = (rand1.nextInt(range) ^ rand2.nextInt(range)).abs();
+    var n5 = (rand1.nextInt(range) ^ rand3.nextInt(range)).abs();
+    var n6 = (rand2.nextInt(range) ^ rand3.nextInt(range)).abs();
+
+    return 'UUID-$n1-$n2-$n3-$n4-$n5-$n6-$c';
+  }
+
   /// The ID of the shared instance.
   String get id;
 
@@ -15,6 +44,7 @@ abstract class SharedType {
 }
 
 typedef SharedStoreProvider = FutureOr<SharedStore?> Function(String id);
+typedef SharedStoreProviderSync = SharedStore? Function(String id);
 
 /// Base class for [SharedStore] implementations.
 abstract class SharedStore extends SharedType {
@@ -22,6 +52,13 @@ abstract class SharedStore extends SharedType {
   factory SharedStore(String id) {
     return createSharedStore(id: id);
   }
+
+  /// Creates a [SharedStore] using a [SharedType.newUUID] as [id].
+  factory SharedStore.fromUUID() => SharedStore(SharedType.newUUID());
+
+  /// Creates a [SharedStore] that can NOT be shared.
+  /// Useful for tests or to have a version that disables the share capabilities.
+  factory SharedStore.notShared() => NotSharedStore();
 
   /// Creates a [SharedStore] from [sharedReference].
   factory SharedStore.fromSharedReference(
@@ -55,6 +92,14 @@ abstract class SharedMap<K, V> extends SharedType {
   factory SharedMap(SharedStore sharedStore, String id) {
     return createSharedMap(sharedStore: sharedStore, id: id);
   }
+
+  /// Creates a [SharedMap] using a [SharedType.newUUID] as [id].
+  factory SharedMap.fromUUID(SharedStore sharedStore) =>
+      SharedMap(sharedStore, SharedType.newUUID());
+
+  /// Creates a [SharedMap] that can NOT be shared.
+  /// Useful for tests or to have a version that disables the share capabilities.
+  factory SharedMap.notShared() => NotSharedMap();
 
   /// Creates a [SharedMap] from [sharedReference].
   factory SharedMap.fromSharedReference(SharedMapReference sharedReference) {
@@ -90,6 +135,42 @@ abstract class SharedMap<K, V> extends SharedType {
   @override
   SharedMapReference sharedReference();
 
+  /// Returns a cached version of this instance.
+  SharedMapCached<K, V> cached({Duration? timeout});
+}
+
+/// Synchronized version of a [SharedMap] implementation.
+abstract class SharedMapSync<K, V> implements SharedMap<K, V> {
+  @override
+  V? get(K key);
+
+  @override
+  V? put(K key, V? value);
+
+  @override
+  V? putIfAbsent(K key, V? absentValue);
+
+  @override
+  V? remove(K key);
+
+  @override
+  List<V?> removeAll(List<K> keys);
+
+  @override
+  List<K> keys();
+
+  @override
+  int length();
+
+  @override
+  SharedMapReference sharedReference();
+
+  /// Returns a cached version of this instance.
+  ///
+  /// Note that [SharedMapSync] implementations could return a fake cache
+  /// implementation (not cached), as a [SharedMapSync] instance could be the
+  /// primary instance responsible for storing entries.
+  @override
   SharedMapCached<K, V> cached({Duration? timeout});
 }
 
@@ -140,8 +221,19 @@ abstract class SharedMapReference extends SharedReference {
   String toString() => 'SharedMapReference${toJson()}';
 }
 
+/// Base class for objects that can be copied and passed to other `Isolate`s,
+/// and automatically detected if it's a copied version ([isIsolateCopy]).
+abstract class SharedObject {
+  SharedObject();
+
+  bool _isolateCopy = false;
+
+  /// Returns `true` if this instance is a copy passed to another `Isolate`.
+  bool get isIsolateCopy => _isolateCopy;
+}
+
 /// A [SharedStore] field/wrapper. This will handle the [SharedStore] in.
-class SharedStoreField {
+class SharedStoreField extends SharedObject {
   static final Map<String, WeakReference<SharedStoreField>> _instances = {};
 
   static SharedStoreField? _getInstanceByID(String id) {
@@ -159,19 +251,133 @@ class SharedStoreField {
     return null;
   }
 
-  /// The global ID of the [sharedStore].
-  String sharedStoreID;
+  factory SharedStoreField(String sharedStoreID) {
+    var ref = _instances[sharedStoreID];
+    if (ref != null) {
+      var o = ref.target;
+      if (o != null) return o;
+    }
 
-  SharedStoreField(this.sharedStoreID) {
-    _setupInstance(fromConstructor: true);
+    var o = SharedStoreField._(sharedStoreID);
+    assert(identical(o, _instances[sharedStoreID]?.target));
+    return o;
   }
 
-  bool _isolateCopy = false;
+  factory SharedStoreField.fromSharedStore(SharedStore sharedStore) {
+    if (sharedStore is NotSharedStore) {
+      return NotSharedStoreField(sharedStore);
+    }
 
-  /// Returns `true` if this instance is a copy passed to another `Isolate`.
-  bool get isIsolateCopy => _isolateCopy;
+    var o = SharedStoreField(sharedStore.id);
+    if (!identical(sharedStore, o.sharedStore)) {
+      throw StateError(
+          "Parameter `sharedStore` instance is NOT the same of `SharedStoreField.sharedStore`> $sharedStore != ${o.sharedStore}");
+    }
+    return o;
+  }
+
+  factory SharedStoreField.from(
+      {SharedStoreField? sharedStoreField,
+      SharedStoreReference? sharedStoreReference,
+      SharedStore? sharedStore,
+      String? sharedStoreID,
+      SharedStoreProviderSync? storeProvider}) {
+    return tryFrom(
+            sharedStoreField: sharedStoreField,
+            sharedStoreReference: sharedStoreReference,
+            sharedStore: sharedStore,
+            sharedStoreID: sharedStoreID,
+            storeProvider: storeProvider) ??
+        (throw ArgumentError(
+            "Null `sharedStoreField`, `sharedStore` and `sharedStoreID`. Please provide one of them."));
+  }
+
+  static SharedStoreField? tryFrom(
+      {SharedStoreField? sharedStoreField,
+      SharedStoreReference? sharedStoreReference,
+      SharedStore? sharedStore,
+      String? sharedStoreID,
+      SharedStoreProviderSync? storeProvider}) {
+    if (sharedStoreField != null) {
+      return sharedStoreField;
+    }
+
+    if (sharedStoreReference != null) {
+      if (sharedStoreReference is NotSharedStoreReference) {
+        sharedStore ??= sharedStoreReference.notSharedStore;
+      } else {
+        sharedStore ??= SharedStore.fromSharedReference(sharedStoreReference);
+      }
+    }
+
+    if (sharedStore != null) {
+      return SharedStoreField.fromSharedStore(sharedStore);
+    }
+
+    if (sharedStoreID != null) {
+      if (storeProvider != null) {
+        var sharedStore = storeProvider(sharedStoreID);
+        if (sharedStore != null) {
+          return SharedStoreField.fromSharedStore(sharedStore);
+        }
+      }
+
+      return SharedStoreField(sharedStoreID);
+    }
+
+    return null;
+  }
+
+  /// The global ID of the [sharedStore].
+  final String sharedStoreID;
+
+  SharedStoreField._(this.sharedStoreID) {
+    _setupInstanceFromConstructor();
+  }
 
   static final Expando<SharedStore> _sharedStoreExpando = Expando();
+  SharedStoreReference? _sharedStoreReference;
+
+  void _setupInstanceFromConstructor() {
+    assert(_sharedStoreExpando[this] == null);
+
+    final sharedStoreID = this.sharedStoreID;
+    assert(_getInstanceByID(sharedStoreID) == null);
+
+    var sharedStore = _sharedStoreExpando[this] = SharedStore(sharedStoreID);
+    _sharedStoreReference = sharedStore.sharedReference();
+
+    _instances[sharedStoreID] = WeakReference(this);
+  }
+
+  void _setupInstance() {
+    var prev = _getInstanceByID(sharedStoreID);
+    if (prev != null) {
+      if (identical(prev, this)) {
+        return;
+      } else {
+        throw StateError(
+            "Previous `SharedStore` instance (id: $sharedStoreID) NOT identical to this instance: $prev != $this");
+      }
+    }
+
+    return _setupInstanceIsolateCopy();
+  }
+
+  void _setupInstanceIsolateCopy() {
+    assert(_sharedStoreExpando[this] == null);
+
+    _isolateCopy = true;
+
+    var sharedStoreReference = _sharedStoreReference ??
+        (throw StateError(
+            "An Isolate copy should have `_sharedStoreReference` defined!"));
+
+    var sharedStore = SharedStore.fromSharedReference(sharedStoreReference);
+    _sharedStoreExpando[this] = sharedStore;
+
+    _instances[sharedStoreID] = WeakReference(this);
+  }
 
   /// The [SharedStore] of this instance. This [SharedStore] will be
   /// automatically shared among `Isolate` copies.
@@ -181,45 +387,188 @@ class SharedStoreField {
     _setupInstance();
 
     var sharedStored = _sharedStoreExpando[this];
-    if (sharedStored != null) return sharedStored;
-
-    var sharedStoreReference = _sharedStoreReference;
-    if (sharedStoreReference != null) {
-      _sharedStoreExpando[this] =
-          sharedStored = SharedStore.fromSharedReference(sharedStoreReference);
-      return sharedStored;
+    if (sharedStored == null) {
+      throw StateError(
+          "After `_setupInstance` `sharedStored` should be defined at `_sharedStoreExpando`");
     }
-
-    _sharedStoreExpando[this] = sharedStored = SharedStore(sharedStoreID);
-    _sharedStoreReference = sharedStored.sharedReference();
 
     return sharedStored;
   }
 
-  SharedStoreReference? _sharedStoreReference;
+  @override
+  String toString() =>
+      'SharedStoreField#$sharedStoreID${isIsolateCopy ? '(Isolate copy)' : ''}';
+}
 
-  void _setupInstance({bool fromConstructor = false}) {
-    final sharedStoreID = this.sharedStoreID;
-
-    var prev = _getInstanceByID(sharedStoreID);
-    if (identical(prev, this)) {
-      return;
+class SharedMapField<K, V> extends SharedObject {
+  factory SharedMapField.fromSharedMap(SharedMap<K, V> sharedMap) {
+    if (sharedMap is NotSharedMap) {
+      return NotSharedMapField(sharedMap as NotSharedMap<K, V>);
     }
 
-    if (!fromConstructor) {
-      _isolateCopy = true;
-
-      var sharedStoreReference = _sharedStoreReference;
-      if (sharedStoreReference != null) {
-        _sharedStoreExpando[this] =
-            SharedStore.fromSharedReference(sharedStoreReference);
-      }
-    } else {
-      var sharedStore =
-          _sharedStoreExpando[this] ??= SharedStore(sharedStoreID);
-      _sharedStoreReference = sharedStore.sharedReference();
+    var o =
+        SharedMapField<K, V>(sharedMap.id, sharedStore: sharedMap.sharedStore);
+    if (!identical(sharedMap, o.sharedMap)) {
+      throw StateError(
+          "Parameter `sharedMap` instance is NOT the same of `SharedMapField.sharedMap`> $sharedMap != ${o.sharedMap}");
     }
-
-    _instances[sharedStoreID] = WeakReference(this);
+    return o;
   }
+
+  factory SharedMapField.from(
+      {SharedMapField<K, V>? sharedMapField,
+      SharedMapReference? sharedMapReference,
+      SharedMap<K, V>? sharedMap,
+      String? sharedMapID,
+      SharedStoreField? sharedStoreField,
+      SharedStore? sharedStore,
+      String? sharedStoreID}) {
+    if (sharedMapField != null) {
+      return sharedMapField;
+    }
+
+    if (sharedMapReference != null) {
+      if (sharedMapReference is NotSharedMapReference) {
+        sharedMap = sharedMapReference.notSharedMap as NotSharedMap<K, V>;
+      } else {
+        sharedMap ??= SharedMap<K, V>.fromSharedReference(sharedMapReference);
+      }
+    }
+
+    if (sharedMap != null) {
+      return SharedMapField.fromSharedMap(sharedMap);
+    }
+
+    if (sharedMapID != null) {
+      return SharedMapField(sharedMapID,
+          sharedStoreField: sharedStoreField,
+          sharedStore: sharedStore,
+          sharedStoreID: sharedStoreID);
+    }
+
+    throw ArgumentError(
+        "Null `sharedMapField`, `sharedMap` and `sharedMapID`. Please provide one of them.");
+  }
+
+  final SharedStoreField _sharedStoreField;
+
+  /// The global ID of the [sharedMap].
+  final String sharedMapID;
+
+  SharedMapField(this.sharedMapID,
+      {SharedStoreField? sharedStoreField,
+      SharedStoreReference? sharedStoreReference,
+      SharedStore? sharedStore,
+      String? sharedStoreID})
+      : _sharedStoreField = SharedStoreField.from(
+            sharedStoreField: sharedStoreField,
+            sharedStoreReference: sharedStoreReference,
+            sharedStore: sharedStore,
+            sharedStoreID: sharedStoreID) {
+    _setupInstanceFromConstructor();
+  }
+
+  SharedStore get sharedStore => _sharedStoreField.sharedStore;
+
+  static final Expando<SharedMap> _sharedMapExpando = Expando();
+
+  SharedMapReference? _sharedMapReference;
+  Future<SharedMap<K, V>>? _resolvingSharedMap;
+
+  void _setupInstanceFromConstructor() {
+    assert(_sharedMapExpando[this] == null);
+    _resolveSharedMapFromStore();
+  }
+
+  FutureOr<SharedMap<K, V>> _setupInstance() {
+    var sharedMap = _sharedMapExpando[this] as SharedMap<K, V>?;
+    if (sharedMap != null) return sharedMap;
+
+    return _setupInstanceIsolateCopy();
+  }
+
+  FutureOr<SharedMap<K, V>> _setupInstanceIsolateCopy() {
+    assert(_sharedMapExpando[this] == null);
+
+    _isolateCopy = true;
+
+    var sharedMapReference = _sharedMapReference;
+
+    if (sharedMapReference != null) {
+      var sharedMap = SharedMap<K, V>.fromSharedReference(sharedMapReference);
+      _sharedMapExpando[this] = sharedMap;
+      return sharedMap;
+    } else {
+      return _resolveSharedMapFromStore();
+    }
+  }
+
+  FutureOr<SharedMap<K, V>> _resolveSharedMapFromStore() {
+    var resolvingSharedMap = _resolvingSharedMap;
+    if (resolvingSharedMap != null) return resolvingSharedMap;
+
+    final sharedStore = this.sharedStore;
+
+    var sharedMapAsync = sharedStore.getSharedMap<K, V>(sharedMapID);
+
+    if (sharedMapAsync is Future<SharedMap<K, V>?>) {
+      return _resolvingSharedMap = sharedMapAsync.then((sharedMap) {
+        sharedMap ??= SharedMap(sharedStore, sharedMapID);
+        _sharedMapExpando[this] = sharedMap;
+        _sharedMapReference = sharedMap.sharedReference();
+        _resolvingSharedMap = null;
+        return sharedMap;
+      });
+    } else {
+      var sharedMap = sharedMapAsync ?? SharedMap(sharedStore, sharedMapID);
+      _sharedMapExpando[this] = sharedMap;
+      _sharedMapReference = sharedMap.sharedReference();
+      return sharedMap;
+    }
+  }
+
+  /// The [SharedMap] of this instance. This [SharedMap] will be
+  /// automatically shared among `Isolate` copies.
+  ///
+  /// See [isIsolateCopy].
+  FutureOr<SharedMap<K, V>> get sharedMap {
+    var sharedMap = _setupInstance();
+    return sharedMap;
+  }
+
+  /// Synchronized alias to [sharedMapSync].
+  /// - Throws a [StateError] if [sharedMap] returns a [Future].
+  SharedMap<K, V> get sharedMapSync {
+    var sharedMap = this.sharedMap;
+    if (sharedMap is! SharedMap<K, V>) {
+      throw StateError(
+          "`sharedMap` not resolved yet! Use the asynchronous getter `sharedMap`.");
+    }
+    return sharedMap;
+  }
+
+  /// Tries a synchronized resolution of [sharedMap] or returns `null`.
+  SharedMap<K, V>? get trySharedMapSync {
+    var sharedMap = this.sharedMap;
+    if (sharedMap is! SharedMap<K, V>) {
+      return null;
+    }
+    return sharedMap;
+  }
+
+  /// Returns a cached version of [sharedMap].
+  /// See [SharedMap.cached].
+  FutureOr<SharedMap<K, V>> sharedMapCached({Duration? timeout}) {
+    var sharedMap = this.sharedMap;
+
+    if (sharedMap is Future<SharedMap<K, V>>) {
+      return sharedMap.then((sharedMap) => sharedMap.cached(timeout: timeout));
+    } else {
+      return sharedMap.cached(timeout: timeout);
+    }
+  }
+
+  @override
+  String toString() =>
+      'SharedMapField#${_sharedStoreField.sharedStoreID}->$sharedMapID${isIsolateCopy ? '(Isolate copy)' : ''}';
 }

--- a/lib/src/shared_map_cached.dart
+++ b/lib/src/shared_map_cached.dart
@@ -9,9 +9,11 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
   /// The default timeout of the cached entries.
   final Duration timeout;
 
-  SharedMapCached(this._sharedMap,
-      {Duration? timeout = const Duration(seconds: 1)})
-      : timeout = const Duration(seconds: 1);
+  /// The default cache timeout (1 sec).
+  static const defaultTimeout = Duration(seconds: 1);
+
+  SharedMapCached(this._sharedMap, {Duration? timeout = defaultTimeout})
+      : timeout = timeout ??= defaultTimeout;
 
   @override
   SharedStore get sharedStore => _sharedMap.sharedStore;

--- a/lib/src/shared_map_generic.dart
+++ b/lib/src/shared_map_generic.dart
@@ -28,16 +28,16 @@ class SharedStoreGeneric implements SharedStore {
       'SharedStoreGeneric[$id]{sharedMaps: ${_sharedMaps.length}}';
 }
 
-class SharedMapGeneric<K, V> implements SharedMap<K, V> {
+class SharedMapGeneric<K, V> implements SharedMapSync<K, V> {
   @override
   final SharedStore sharedStore;
 
   @override
   final String id;
 
-  final Map<K, V?> _entries;
+  final Map<K, V?> _entries = {};
 
-  SharedMapGeneric(this.sharedStore, this.id) : _entries = {};
+  SharedMapGeneric(this.sharedStore, this.id);
 
   @override
   V? get(K key) {
@@ -78,21 +78,19 @@ class SharedMapGeneric<K, V> implements SharedMap<K, V> {
   SharedMapReference sharedReference() =>
       SharedMapReferenceGeneric(id, sharedStore.sharedReference());
 
-  SharedMapCached<K, V>? _cached;
+  late final SharedMapCached<K, V> _cached = SharedMapCacheGeneric<K, V>(this);
 
   @override
-  SharedMapCached<K, V> cached({Duration? timeout}) =>
-      _cached ??= SharedMapCacheGeneric<K, V>(this, timeout: timeout);
+  SharedMapCached<K, V> cached({Duration? timeout}) => _cached;
 }
 
+/// A fake implementation (not cached) of [SharedMapCached].
 class SharedMapCacheGeneric<K, V> implements SharedMapCached<K, V> {
-  final SharedMapGeneric<K, V> _sharedMap;
+  final SharedMapSync<K, V> _sharedMap;
   @override
   final Duration timeout;
 
-  SharedMapCacheGeneric(this._sharedMap,
-      {Duration? timeout = const Duration(seconds: 1)})
-      : timeout = const Duration(seconds: 1);
+  SharedMapCacheGeneric(this._sharedMap) : timeout = Duration.zero;
 
   @override
   String get id => _sharedMap.id;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_map
 description: Offers a versatile, synchronized Map for efficient sharing between Dart application parts, including Isolates or external apps.
-version: 1.0.5
+version: 1.0.6
 repository: https://github.com/gmpassos/shared_map
 
 environment:

--- a/test/shared_map_generic_test.dart
+++ b/test/shared_map_generic_test.dart
@@ -119,5 +119,22 @@ void main() {
       expect(await m1.keys(), equals(['c']));
       expect(await m1.length(), equals(1));
     });
+
+    test('newUUID', () async {
+      var store1 = SharedStoreGeneric(SharedType.newUUID());
+
+      expect(store1.id, startsWith('UUID-'));
+
+      var m1 = await store1.getSharedMap<String, int>(SharedType.newUUID());
+      expect(m1, isNotNull);
+      expect(m1, isA<SharedMapGeneric<String, int>>());
+      expect(m1!.id, startsWith('UUID-'));
+
+      var va1 = await m1.get('a');
+      expect(va1, isNull);
+
+      var va2 = m1.put('a', 11);
+      expect(va2, equals(11));
+    });
   });
 }

--- a/test/shared_map_isolate_test.dart
+++ b/test/shared_map_isolate_test.dart
@@ -195,7 +195,7 @@ void main() {
     test('basic', () async {
       final store1 = sharedStoreField.sharedStore;
 
-      var m1 = await store1.getSharedMap(sharedMapID);
+      var m1 = await store1.getSharedMap<String, int>(sharedMapID);
 
       var va1 = await m1!.get('a');
       expect(va1, isNull);
@@ -221,6 +221,37 @@ void main() {
 
       expect(va4, equals(111));
       expect(await m1.get('a'), equals(111));
+
+      var sharedMapField = SharedMapField.fromSharedMap(m1);
+
+      {
+        var sharedMapField2 = SharedMapField(m1.id, sharedStore: store1);
+        expect(identical(sharedMapField2.sharedMapSync, m1), isTrue);
+      }
+
+      {
+        expect(sharedMapField.trySharedMapSync?.id, equals(m1.id));
+
+        var m2 = sharedMapField.sharedMapSync;
+        expect(m2.id, equals(m1.id));
+
+        expect(identical(m2, m1), isTrue);
+      }
+
+      var va5 = await Isolate.run<int?>(() async {
+        var m3 = await sharedMapField.sharedMap;
+
+        var va5 = await m3.get('a');
+        if (va5 != 111) throw StateError("Expected: 111 ; got: $va5");
+
+        va5 = await m3.put('a', 11111);
+        if (va5 != 11111) throw StateError("Expected: 11111 ; got: $va5");
+
+        return va5;
+      });
+
+      expect(va5, equals(11111));
+      expect(await m1.get('a'), equals(11111));
     });
   });
 }


### PR DESCRIPTION
- New `NotSharedMap`, `NotSharedStore` and `SharedMapSync`.

- Refactored `SharedMapField` and `SharedStoreField`:
  - Handle non-shared and shared instances appropriately.
  - Improved handling of isolate copies and shared references for better consistency across isolates.

- `SharedMap`:
  - Improved resolution and caching mechanisms to enhance performance and reduce redundant operations.