### PR TITLE
v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.10
+
+- `SharedMapCached`:
+  - Introduces async call caching for `get`, `keys`, `values`, `entries` and `length` operations,
+    to avoid simultaneous asynchronous calls (fetching) for the same operation. 
+
+- `SharedStoreIsolateServer`:
+  - Fix  call to `getSharedMap<K,V>()` with correct `K` and `V` casting when requested by `SharedStoreIsolateClient`.
+
 ## 1.0.9
 
 - `SharedMap`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `SharedStoreIsolateServer`:
   - Fix  call to `getSharedMap<K,V>()` with correct `K` and `V` casting when requested by `SharedStoreIsolateClient`.
 
+- Improve `SharedMap.toString` implementations.
+
 ## 1.0.9
 
 - `SharedMap`:

--- a/lib/src/not_shared_map.dart
+++ b/lib/src/not_shared_map.dart
@@ -178,6 +178,11 @@ class NotSharedMap<K, V> implements SharedMapSync<K, V> {
   @override
   SharedMapReference sharedReference() =>
       _sharedReference ??= NotSharedMapReference(this);
+
+  @override
+  String toString() {
+    return 'NotSharedMap<$K,$V>[$id@${sharedStore.id}]{entries: ${_entries.length}}';
+  }
 }
 
 class NotSharedStoreReference extends SharedStoreReference {

--- a/lib/src/shared_map_cached.dart
+++ b/lib/src/shared_map_cached.dart
@@ -75,23 +75,38 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
       }
     }
 
+    var getAsync = _getAsync;
+    if (getAsync != null) {
+      return getAsync;
+    }
+
     var val = _sharedMap.get(key);
     return _cacheValue(key, val, now);
   }
 
+  Future<V?>? _getAsync;
+
   FutureOr<V?> _cacheValue(K key, FutureOr<V?> value, DateTime now) {
     if (value is Future<V?>) {
-      return value.then((value) {
+      return _getAsync = value.then((value) {
         if (value != null) {
           _cache[key] = (now, value);
         }
+        _getAsync = null;
         return value;
+      }, onError: (e) {
+        _getAsync = null;
+        throw e;
       });
-    } else if (value != null) {
-      _cache[key] = (now, value);
-      return value;
     } else {
-      return null;
+      _getAsync = null;
+
+      if (value != null) {
+        _cache[key] = (now, value);
+        return value;
+      } else {
+        return null;
+      }
     }
   }
 
@@ -143,18 +158,30 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
       }
     }
 
+    var keysAsync = _keysAsync;
+    if (keysAsync != null) {
+      return keysAsync;
+    }
+
     var keys = _sharedMap.keys();
     return _cacheKeys(keys, now);
   }
 
+  Future<List<K>>? _keysAsync;
+
   FutureOr<List<K>> _cacheKeys(FutureOr<List<K>> keys, DateTime now) {
     if (keys is Future<List<K>>) {
-      return keys.then((keys) {
+      return _keysAsync = keys.then((keys) {
         _keysCached = (now, keys);
+        _keysAsync = null;
         return keys;
+      }, onError: (e) {
+        _keysAsync = null;
+        throw e;
       });
     } else {
       _keysCached = (now, keys);
+      _keysAsync = null;
       return keys;
     }
   }
@@ -180,18 +207,30 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
       }
     }
 
+    var valuesAsync = _valuesAsync;
+    if (valuesAsync != null) {
+      return valuesAsync;
+    }
+
     var values = _sharedMap.values();
     return _cacheValues(values, now);
   }
 
+  Future<List<V>>? _valuesAsync;
+
   FutureOr<List<V>> _cacheValues(FutureOr<List<V>> values, DateTime now) {
     if (values is Future<List<V>>) {
-      return values.then((values) {
+      return _valuesAsync = values.then((values) {
         _valuesCached = (now, values);
+        _valuesAsync = null;
         return values;
+      }, onError: (e) {
+        _valuesAsync = null;
+        throw e;
       });
     } else {
       _valuesCached = (now, values);
+      _valuesAsync = null;
       return values;
     }
   }
@@ -218,19 +257,31 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
       }
     }
 
+    var entriesAsync = _entriesAsync;
+    if (entriesAsync != null) {
+      return entriesAsync;
+    }
+
     var entries = _sharedMap.entries();
     return _cacheEntries(entries, now);
   }
 
+  Future<List<MapEntry<K, V>>>? _entriesAsync;
+
   FutureOr<List<MapEntry<K, V>>> _cacheEntries(
       FutureOr<List<MapEntry<K, V>>> entries, DateTime now) {
     if (entries is Future<List<MapEntry<K, V>>>) {
-      return entries.then((values) {
+      return _entriesAsync = entries.then((values) {
         _entriesCached = (now, values);
+        _entriesAsync = null;
         return values;
+      }, onError: (e) {
+        _entriesAsync = null;
+        throw e;
       });
     } else {
       _entriesCached = (now, entries);
+      _entriesAsync = null;
       return entries;
     }
   }
@@ -260,18 +311,30 @@ class SharedMapCached<K, V> implements SharedMap<K, V> {
       }
     }
 
+    var lengthAsync = _lengthAsync;
+    if (lengthAsync != null) {
+      return lengthAsync;
+    }
+
     var length = _sharedMap.length();
     return _cacheKeysLength(length, now);
   }
 
+  Future<int>? _lengthAsync;
+
   FutureOr<int> _cacheKeysLength(FutureOr<int> length, DateTime now) {
     if (length is Future<int>) {
-      return length.then((length) {
+      return _lengthAsync = length.then((length) {
         _keysLengthCached = (now, length);
+        _lengthAsync = null;
         return length;
+      }, onError: (e) {
+        _lengthAsync = null;
+        throw e;
       });
     } else {
       _keysLengthCached = (now, length);
+      _lengthAsync = null;
       return length;
     }
   }

--- a/lib/src/shared_map_generic.dart
+++ b/lib/src/shared_map_generic.dart
@@ -172,6 +172,11 @@ class SharedMapGeneric<K, V> implements SharedMapSync<K, V> {
 
   @override
   SharedMapCached<K, V> cached({Duration? timeout}) => _cached;
+
+  @override
+  String toString() {
+    return 'SharedMapGeneric<$K,$V>[$id@${sharedStore.id}]{entries: ${_entries.length}}';
+  }
 }
 
 /// A fake implementation (not cached) of [SharedMapCached].
@@ -266,7 +271,7 @@ class SharedMapCacheGeneric<K, V> implements SharedMapCached<K, V> {
 
   @override
   String toString() =>
-      'SharedMapCachedGeneric[$id@${sharedStore.id}]{timeout: $timeout}->$_sharedMap';
+      'SharedMapCachedGeneric<$K,$V>[$id@${sharedStore.id}]{timeout: $timeout}->$_sharedMap';
 }
 
 class SharedStoreReferenceGeneric extends SharedStoreReference {

--- a/lib/src/shared_map_isolate.dart
+++ b/lib/src/shared_map_isolate.dart
@@ -65,6 +65,10 @@ class SharedStoreIsolateServer extends SharedStoreIsolate {
   }) {
     var sharedMap = _sharedMaps[id];
     if (sharedMap != null) {
+      if (sharedMap is! SharedMap<K, V>) {
+        throw StateError(
+            "[$this] Can't cast `sharedMap` to `SharedMap<$K, $V>`: $sharedMap");
+      }
       return sharedMap as SharedMap<K, V>;
     }
 
@@ -129,7 +133,7 @@ class SharedStoreIsolateClient extends SharedStoreIsolate {
     var msgID = ++_msgIDCounter;
     var completer = _waitingResponse[msgID] = Completer();
 
-    _CallCasted<K, V> callCasted = _buildCallCasted();
+    _CallCasted<K, V> callCasted = _buildCallCasted<K, V>();
 
     _serverPort.send([_receivePort.sendPort, msgID, id, callCasted]);
 
@@ -144,8 +148,8 @@ class SharedStoreIsolateClient extends SharedStoreIsolate {
     });
   }
 
-  /// Generates the lambda [Function] that will passed to the
-  /// [SharedMapIsolateServer] to allow correct casted call to [getSharedMap].
+  /// Generates the lambda [Function] that will be passed to the
+  /// [SharedMapIsolateServer] to allow the correct casted call to [getSharedMap]`<K,V>()`.
   _CallCasted<K, V> _buildCallCasted<K, V>() => (f) => f<K, V>();
 
   @override
@@ -370,7 +374,7 @@ class SharedMapIsolateServer<K, V> extends SharedMapIsolate<K, V>
 
   @override
   String toString() =>
-      'SharedMapIsolateServer[$id@${sharedStore.id}]{entries: ${_entries.length}';
+      'SharedMapIsolateServer<$K,$V>[$id@${sharedStore.id}]{entries: ${_entries.length}}';
 }
 
 class SharedMapIsolateClient<K, V> extends SharedMapIsolate<K, V>
@@ -532,7 +536,7 @@ class SharedMapIsolateClient<K, V> extends SharedMapIsolate<K, V>
       SharedMapReferenceIsolate(id, sharedStore.sharedReference(), _serverPort);
 
   @override
-  String toString() => 'SharedMapIsolateClient[$id@${sharedStore.id}]';
+  String toString() => 'SharedMapIsolateClient<$K,$V>[$id@${sharedStore.id}]';
 }
 
 class SharedStoreReferenceIsolate extends SharedStoreReference {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_map
 description: Offers a versatile, synchronized Map for efficient sharing between Dart application parts, including Isolates or external apps.
-version: 1.0.9
+version: 1.0.10
 repository: https://github.com/gmpassos/shared_map
 
 environment:

--- a/test/shared_map_isolate_test.dart
+++ b/test/shared_map_isolate_test.dart
@@ -332,10 +332,10 @@ void main() {
 
       expect(events, equals([('put', 'a', 11), ('put', 'a', 111)]));
 
-      var cached = m2.cached();
+      var cached1 = m2.cached();
 
-      var ca1 = cached.get('a');
-      var ca2 = cached.get('a');
+      var ca1 = cached1.get('a');
+      var ca2 = cached1.get('a');
 
       expect(await ca1, equals(111));
       expect(await ca2, equals(111));
@@ -343,7 +343,16 @@ void main() {
       var va5 = await Isolate.run<int?>(() async {
         var store5 = SharedStore.fromSharedReference(sharedStoreReference);
         var m5 = await store5.getSharedMap(sharedMapID);
-        var va5 = await m5?.remove('a');
+
+        var cached2 = m5!.cached();
+
+        var ca1 = cached2.get('a');
+        var ca2 = cached2.get('a');
+
+        if (await ca1 != 111) throw StateError("Expect: 111 ; got: $ca1");
+        if (await ca2 != 111) throw StateError("Expect: 111 ; got: $ca2");
+
+        var va5 = await m5.remove('a');
         return va5;
       });
 

--- a/test/shared_map_isolate_test.dart
+++ b/test/shared_map_isolate_test.dart
@@ -267,7 +267,7 @@ void main() {
       var va5 = await Isolate.run<int?>(() async {
         var store5 = SharedStore.fromSharedReference(sharedStoreReference);
         var m5 = await store5.getSharedMap(sharedMapID);
-        var va5 = await m5?.remove('a');
+        var va5 = await m5?.cached().remove('a');
         return va5;
       });
 
@@ -402,7 +402,7 @@ void main() {
       var va4 = await Isolate.run<int?>(() async {
         final store3 = sharedStoreField.sharedStore;
         var m3 = await store3.getSharedMap(sharedMapID);
-        var va4 = await m3?.put('a', 111);
+        var va4 = await m3?.cached().put('a', 111);
         return va4;
       });
 

--- a/test/shared_map_isolate_test.dart
+++ b/test/shared_map_isolate_test.dart
@@ -332,6 +332,14 @@ void main() {
 
       expect(events, equals([('put', 'a', 11), ('put', 'a', 111)]));
 
+      var cached = m2.cached();
+
+      var ca1 = cached.get('a');
+      var ca2 = cached.get('a');
+
+      expect(await ca1, equals(111));
+      expect(await ca2, equals(111));
+
       var va5 = await Isolate.run<int?>(() async {
         var store5 = SharedStore.fromSharedReference(sharedStoreReference);
         var m5 = await store5.getSharedMap(sharedMapID);

--- a/test/shared_map_isolate_test.dart
+++ b/test/shared_map_isolate_test.dart
@@ -218,7 +218,7 @@ void main() {
       expect(await m1.clear(), equals(0));
     });
 
-    test('basic', () async {
+    test('basic 1', () async {
       var store2 = SharedStore('t2');
 
       var m2 = await store2.getSharedMap<String, int>('m2');
@@ -241,6 +241,74 @@ void main() {
 
       final sharedStoreReference = store2.sharedReference();
       final sharedMapID = m2.id;
+
+      var va3 = await Isolate.run<int?>(() async {
+        var store3 = SharedStore.fromSharedReference(sharedStoreReference);
+        var m3 = await store3.getSharedMap(sharedMapID);
+        var va3 = await m3?.get('a');
+        return va3;
+      });
+
+      expect(va3, equals(11));
+
+      expect(events, equals([('put', 'a', 11)]));
+
+      var va4 = await Isolate.run<int?>(() async {
+        var store4 = SharedStore.fromSharedReference(sharedStoreReference);
+        var m4 = await store4.getSharedMap(sharedMapID);
+        var va4 = await m4?.put('a', 111);
+        return va4;
+      });
+
+      expect(va4, equals(111));
+
+      expect(events, equals([('put', 'a', 11), ('put', 'a', 111)]));
+
+      var va5 = await Isolate.run<int?>(() async {
+        var store5 = SharedStore.fromSharedReference(sharedStoreReference);
+        var m5 = await store5.getSharedMap(sharedMapID);
+        var va5 = await m5?.remove('a');
+        return va5;
+      });
+
+      expect(va5, equals(111));
+
+      expect(events,
+          equals([('put', 'a', 11), ('put', 'a', 111), ('rm', 'a', 111)]));
+    });
+
+    test('basic 2', () async {
+      var store2 = SharedStore('t3');
+
+      final sharedStoreReference = store2.sharedReference();
+      final sharedMapID = 'm2';
+
+      var va0 = await Isolate.run<int?>(() async {
+        var store3 = SharedStore.fromSharedReference(sharedStoreReference);
+        var m3 = await store3.getSharedMap<String, int>(sharedMapID);
+        var va0 = await m3?.get('a');
+        return va0;
+      });
+
+      expect(va0, isNull);
+
+      var m2 = await store2.getSharedMap<String, int>(sharedMapID);
+      expect(m2, isNotNull);
+
+      var events = <(String, String, int?)>[];
+
+      m2!.onPut = (k, v) => events.add(('put', k, v));
+      m2.onRemove = (k, v) => events.add(('rm', k, v));
+
+      expect(events, equals([]));
+
+      var va1 = await m2.get('a');
+      expect(va1, isNull);
+
+      var va2 = await m2.put('a', 11);
+      expect(va2, equals(11));
+
+      expect(events, equals([('put', 'a', 11)]));
 
       var va3 = await Isolate.run<int?>(() async {
         var store3 = SharedStore.fromSharedReference(sharedStoreReference);


### PR DESCRIPTION
- `SharedMapCached`:
  - Introduces async call caching for `get`, `keys`, `values`, `entries` and `length` operations, to avoid simultaneous asynchronous calls (fetching) for the same operation.

- `SharedStoreIsolateServer`:
  - Fix  call to `getSharedMap<K,V>()` with correct `K` and `V` casting when requested by `SharedStoreIsolateClient`.