### PR TITLE
v1.1.3 - Async resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.3
+
+- `SharedStore`:
+  - Added `getSharedObject`, `getSharedObjectReference` and `registerSharedObject`.
+- `SharedObjectField`:
+  - Added `sharedObjectAsync` and `isResolvingReference`.
+- `SharedMap`:
+  - Shared to asynchronous "constructors" (static methods): `fromID`, `fromUUID`, `from`.
+
 ## 1.1.2
 
 - New `SharedObjectReferenceable`: `SharedObject` + `ReferenceableType`

--- a/lib/src/not_shared_map.dart
+++ b/lib/src/not_shared_map.dart
@@ -1,6 +1,7 @@
 import 'shared_map_base.dart';
 import 'shared_map_cached.dart';
 import 'shared_object.dart';
+import 'shared_reference.dart';
 
 /// NOT shared implementation of [SharedStore].
 class NotSharedStore implements SharedStore {
@@ -35,6 +36,21 @@ class NotSharedStore implements SharedStore {
   @override
   SharedStoreReference sharedReference() =>
       _sharedReference ??= NotSharedStoreReference(this);
+
+  @override
+  O? getSharedObject<O extends ReferenceableType>(String id, {Type? t}) => null;
+
+  @override
+  R? getSharedObjectReference<O extends ReferenceableType,
+          R extends SharedReference>(String id, {Type? t}) =>
+      null;
+
+  @override
+  void registerSharedObject<O extends ReferenceableType>(O o) {
+    if (o is SharedMap) {
+      throw StateError("Can't register a `SharedMap`: $o");
+    }
+  }
 }
 
 /// NOT shared implementation of [SharedMap].
@@ -311,6 +327,12 @@ class NotSharedStoreField extends NotSharedObject implements SharedStoreField {
   SharedStore get sharedObject => sharedStore;
 
   @override
+  SharedStore get sharedObjectAsync => sharedStore;
+
+  @override
+  bool get isResolvingReference => false;
+
+  @override
   String get sharedObjectID => sharedStoreID;
 
   @override
@@ -330,6 +352,12 @@ class NotSharedMapField<K, V> extends NotSharedObject
   SharedMap<K, V> get sharedObject => sharedMap;
 
   @override
+  SharedMap<K, V> get sharedObjectAsync => sharedMap;
+
+  @override
+  bool get isResolvingReference => false;
+
+  @override
   String get sharedObjectID => sharedMapID;
 
   @override
@@ -343,6 +371,9 @@ class NotSharedMapField<K, V> extends NotSharedObject
 
   @override
   SharedMap<K, V> get sharedMap => _notSharedMap;
+
+  @override
+  SharedMap<K, V> get sharedMapAsync => _notSharedMap;
 
   @override
   SharedMap<K, V> sharedMapCached({Duration? timeout}) =>

--- a/lib/src/shared_map_extension.dart
+++ b/lib/src/shared_map_extension.dart
@@ -31,6 +31,22 @@ extension FutureSharedMapExtension<K, V> on Future<SharedMap<K, V>> {
 
   Future<SharedMapCached<K, V>> cached({Duration? timeout}) =>
       then((o) => o.cached(timeout: timeout));
+
+  Future<SharedMap<K, V>> setCallbacks(
+          {SharedMapEntryCallback<K, V>? onPut,
+          SharedMapEntryCallback<K, V>? onRemove}) =>
+      then((o) {
+        o.setCallbacks(onPut: onPut, onRemove: onRemove);
+        return o;
+      });
+
+  Future<SharedMap<K, V>> setCallbacksDynamic<K1, V1>(
+          {SharedMapEntryCallback<K1, V1>? onPut,
+          SharedMapEntryCallback<K1, V1>? onRemove}) =>
+      then((o) {
+        o.setCallbacksDynamic(onPut: onPut, onRemove: onRemove);
+        return o;
+      });
 }
 
 /// Extension on [FutureOr]<[SharedMap]`<K, V>`>
@@ -140,6 +156,36 @@ extension FutureOrSharedMapExtension<K, V> on FutureOr<SharedMap<K, V>> {
       return self.cached(timeout: timeout);
     } else {
       return self.cached(timeout: timeout);
+    }
+  }
+
+  FutureOr<SharedMap<K, V>> setCallbacks(
+      {SharedMapEntryCallback<K, V>? onPut,
+      SharedMapEntryCallback<K, V>? onRemove}) {
+    var self = this;
+    if (self is Future<SharedMap<K, V>>) {
+      return self.then((o) {
+        o.setCallbacks(onPut: onPut, onRemove: onRemove);
+        return o;
+      });
+    } else {
+      self.setCallbacks(onPut: onPut, onRemove: onRemove);
+      return self;
+    }
+  }
+
+  FutureOr<SharedMap<K, V>> setCallbacksDynamic<K1, V1>(
+      {SharedMapEntryCallback<K1, V1>? onPut,
+      SharedMapEntryCallback<K1, V1>? onRemove}) {
+    var self = this;
+    if (self is Future<SharedMap<K, V>>) {
+      return self.then((o) {
+        o.setCallbacksDynamic(onPut: onPut, onRemove: onRemove);
+        return o;
+      });
+    } else {
+      self.setCallbacksDynamic(onPut: onPut, onRemove: onRemove);
+      return self;
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_map
 description: Offers a versatile, synchronized Map for efficient sharing between Dart application parts, including Isolates or external apps.
-version: 1.1.2
+version: 1.1.3
 repository: https://github.com/gmpassos/shared_map
 
 environment:

--- a/test/shared_object_test.dart
+++ b/test/shared_object_test.dart
@@ -3,15 +3,17 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'package:shared_map/shared_object.dart';
-import 'package:shared_map/src/shared_object_isolate.dart';
+import 'package:shared_map/shared_map.dart';
+import 'package:shared_map/shared_object_isolate.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
   group('SharedObjectIsolate (MyCounter)', () {
     test('basic', () async {
-      var c1 = MyCounter("c1");
+      var store1 = SharedStore('store1');
+
+      var c1 = await MyCounter.fromID(store1, "c1");
 
       expect(c1.get(), equals(0));
       expect(c1.set(100), equals(100));
@@ -93,17 +95,35 @@ void main() {
 
       expect(n4, equals(208));
 
-      final field2 = MyCounterField.fromID(c1.id);
+      final counterID = c1.id;
+      final store1Ref = store1.sharedReference();
+      final field2 = MyCounterField.fromID(counterID, store1Ref);
 
       expect(identical(field2.sharedObject, c1), isTrue);
+      expect(field2.sharedObject.get(), equals(208));
+
+      var n5 = await Isolate.run(() async {
+        final field3 = MyCounterField.fromID(counterID, store1Ref);
+
+        if (!field3.isResolvingReference) {
+          throw StateError("Expect `isResolvingReference = true` for: $field3");
+        }
+
+        var counter2 = await field3.sharedObjectAsync;
+        var n5 = await counter2.get();
+        return n5;
+      });
+
+      expect(n5, equals(208));
     });
   });
 }
 
 abstract class MyCounter implements SharedObjectIsolate<MyCounterReference> {
-  factory MyCounter(String id) {
+  /*
+  factory MyCounter(SharedStore sharedStore, String id) {
     var counter = ReferenceableType.getOrCreateSharedObject<MyCounter>(id,
-        ifAbsent: _MyCounterMain.new);
+        ifAbsent: (id) => _MyCounterMain(sharedStore, id));
 
     var counter2 = ReferenceableType.getSharedObject<MyCounter>(id);
 
@@ -111,11 +131,49 @@ abstract class MyCounter implements SharedObjectIsolate<MyCounterReference> {
 
     return counter;
   }
+   */
+
+  static FutureOr<MyCounter> fromID(SharedStore sharedStore, String id) {
+    var o = sharedStore.getSharedObject<MyCounter>(id);
+
+    if (o is Future<MyCounter?>) {
+      return o.then((o) {
+        if (o != null) return o;
+        return _getReferenceOrCreate(sharedStore, id);
+      });
+    }
+
+    if (o != null) return o;
+    return _getReferenceOrCreate(sharedStore, id);
+  }
+
+  static Future<MyCounter> _getReferenceOrCreate(
+      SharedStore sharedStore, String id) async {
+    var ref = await sharedStore
+        .getSharedObjectReference<MyCounter, MyCounterReference>(id);
+
+    if (ref != null) {
+      return _MyCounterAuxiliary(sharedStore, id, ref.serverPort);
+    } else {
+      return _MyCounterMain(sharedStore, id);
+    }
+  }
 
   factory MyCounter.fromReference(MyCounterReference reference) {
+    var sharedStore =
+        SharedStore.fromSharedReference(reference.sharedStoreReference);
+
+    var counterAsync = sharedStore.getSharedObject<MyCounter>(reference.id);
+    if (counterAsync is MyCounter) {
+      return counterAsync;
+    }
+
     var counter = ReferenceableType.getOrCreateSharedObject<MyCounter>(
         reference.id,
-        ifAbsent: (id) => _MyCounterAuxiliary(id, reference.serverPort));
+        ifAbsent: (id) => _MyCounterAuxiliary(
+            SharedStore.fromSharedReference(reference.sharedStoreReference),
+            id,
+            reference.serverPort));
 
     assert(identical(
         ReferenceableType.getSharedObject<MyCounter>(reference.id), counter));
@@ -123,18 +181,27 @@ abstract class MyCounter implements SharedObjectIsolate<MyCounterReference> {
     return counter;
   }
 
-  factory MyCounter.from({MyCounterReference? reference, String? id}) {
+  static FutureOr<MyCounter> from(
+      {MyCounterReference? reference,
+      String? id,
+      SharedStoreReference? sharedStoreReference,
+      SharedStore? sharedStore,
+      String? sharedStoreID}) {
     if (reference != null) {
       return MyCounter.fromReference(reference);
     }
 
     if (id != null) {
-      return MyCounter(id);
+      sharedStore ??=
+          SharedStore.from(reference: sharedStoreReference, id: sharedStoreID);
+      return MyCounter.fromID(sharedStore, id);
     }
 
     throw StateError(
-        "Null values for both `reference` and `id` parameters! Please provide at least one.");
+        "Null values for `reference`, `sharedStore` and `id` parameters! Please provide `reference` or `sharedStore` and `id`");
   }
+
+  SharedStore get sharedStore;
 
   FutureOr<int> get();
 
@@ -151,13 +218,21 @@ enum MyCounterOperation {
 
 class _MyCounterMain extends SharedObjectIsolateMain<MyCounterReference>
     implements MyCounter {
+  final SharedStore _sharedStore;
+
+  @override
+  SharedStore get sharedStore => _sharedStore;
+
   int _counter;
 
-  _MyCounterMain(super.id, {int counter = 0}) : _counter = counter;
+  _MyCounterMain(this._sharedStore, super.id, {int counter = 0})
+      : _counter = counter {
+    _sharedStore.registerSharedObject<MyCounter>(this);
+  }
 
   @override
   MyCounterReference sharedReference() =>
-      MyCounterReference(id, isolateSendPort);
+      MyCounterReference(id, _sharedStore.sharedReference(), isolateSendPort);
 
   @override
   void onReceiveIsolateRequestMessage(SharedObjectIsolateRequestMessage m) {
@@ -202,13 +277,21 @@ class _MyCounterMain extends SharedObjectIsolateMain<MyCounterReference>
 class _MyCounterAuxiliary
     extends SharedObjectIsolateAuxiliary<MyCounterReference, int>
     implements MyCounter {
+  final SharedStore _sharedStore;
+
+  @override
+  SharedStore get sharedStore => _sharedStore;
+
   @override
   SendPort serverPort;
 
-  _MyCounterAuxiliary(super.id, this.serverPort);
+  _MyCounterAuxiliary(this._sharedStore, super.id, this.serverPort) {
+    _sharedStore.registerSharedObject<MyCounter>(this);
+  }
 
   @override
-  MyCounterReference sharedReference() => MyCounterReference(id, serverPort);
+  MyCounterReference sharedReference() =>
+      MyCounterReference(id, _sharedStore.sharedReference(), serverPort);
 
   @override
   Future<int> get() => sendRequestNotNull([MyCounterOperation.get]);
@@ -225,22 +308,43 @@ class _MyCounterAuxiliary
 }
 
 class MyCounterReference extends SharedReferenceIsolate {
-  MyCounterReference(super.id, super.serverPort);
+  final SharedStoreReference sharedStoreReference;
+
+  MyCounterReference(super.id, this.sharedStoreReference, super.serverPort);
 }
 
 class MyCounterField
     extends SharedObjectField<MyCounterReference, MyCounter, MyCounterField> {
-  static final _instanceHandler =
-      SharedFieldInstanceHandler<MyCounterReference, MyCounter, MyCounterField>(
-    fieldInstantiator: MyCounterField._fromID,
-    sharedObjectInstantiator: MyCounter.from,
-  );
+  /// Resolves the [SharedFieldInstanceHandler] for each [SharedStore] of [sharedStoreReference].
+  static SharedFieldInstanceHandler<MyCounterReference, MyCounter,
+      MyCounterField> _instanceHandler(
+          SharedStoreReference sharedStoreReference) =>
+      SharedFieldInstanceHandler(
+        fieldInstantiator: (id, {sharedObjectReference}) =>
+            MyCounterField._fromID(id, sharedStoreReference,
+                sharedObjectReference: sharedObjectReference),
+        sharedObjectInstantiator: ({reference, id}) => MyCounter.from(
+            reference: reference,
+            id: id,
+            sharedStoreReference: sharedStoreReference),
+        group: (SharedStore, sharedStoreReference.id),
+      );
 
-  MyCounterField._fromID(String id)
-      : super.fromID(id, instanceHandler: _instanceHandler);
-
-  factory MyCounterField.fromID(String id) => _instanceHandler.fromID(id);
+  factory MyCounterField.fromID(
+          String id, SharedStoreReference sharedStoreReference) =>
+      _instanceHandler(sharedStoreReference).fromID(id);
 
   factory MyCounterField.fromSharedObject(MyCounter o) =>
-      _instanceHandler.fromSharedObject(o);
+      _instanceHandler(o.sharedStore.sharedReference()).fromSharedObject(o);
+
+  final SharedStoreField _sharedStoreField;
+
+  MyCounterField._fromID(String id, SharedStoreReference sharedStoreReference,
+      {super.sharedObjectReference})
+      : _sharedStoreField =
+            SharedStoreField.from(sharedStoreReference: sharedStoreReference),
+        super.fromID(id,
+            instanceHandler: _instanceHandler(sharedStoreReference));
+
+  SharedStore get sharedStore => _sharedStoreField.sharedStore;
 }


### PR DESCRIPTION
- `SharedStore`:
  - Added `getSharedObject`, `getSharedObjectReference` and `registerSharedObject`.
- `SharedObjectField`:
  - Added `sharedObjectAsync` and `isResolvingReference`.
- `SharedMap`:
  - Shared to asynchronous "constructors" (static methods): `fromID`, `fromUUID`, `from`.